### PR TITLE
feat: extend silv_predict_biomass() to all 7 models + improve eq_biomass_*() docs

### DIFF
--- a/R/predict-biomass.R
+++ b/R/predict-biomass.R
@@ -22,12 +22,19 @@ ModelBiomass <- S7::new_class(
 #' Computes the biomass of a tree species using species-specific allometric
 #' equations (in kg). Currently, only equations for Spain are available.
 #'
-#' @param diameter A numeric vector of tree diameters (in cm).
+#' @param diameter A numeric vector of tree diameters at breast height (in cm).
 #' @param height A numeric vector of tree heights (in m).
 #' @param model A function. A function with the structure \code{eq_biomass_*()} with
 #' additional arguments depending on the model used.
 #' @param ntrees An optional numeric value indicating the number of trees in
 #' this diameter-height class. Defaults to 1 if \code{NULL}.
+#' @param rcd An optional numeric vector of root collar diameters (in cm). Required
+#' for \code{\link{eq_biomass_menendez_2022}}, which uses root collar diameter
+#' instead of diameter at breast height. Defaults to \code{diameter} if \code{NULL}.
+#' @param bp An optional numeric vector of biomass packing values (in m\ifelse{html}{\out{<sup>3</sup>}}{$^3$}). Required
+#' for a subset of species in \code{\link{eq_biomass_menendez_2022}} (e.g.
+#' \emph{Pinus halepensis}, \emph{Pinus nigra}, \emph{Quercus suber},
+#' \emph{Evergreen broadleaves}).
 #' @param quiet A logical value. If \code{TRUE}, suppresses any informational messages.
 #'
 #' @return A numeric vector
@@ -40,6 +47,14 @@ ModelBiomass <- S7::new_class(
 #'
 #' - **[eq_biomass_ruiz_peinado_2011()]**: Developed for softwood species in Spain.
 #' - **[eq_biomass_ruiz_peinado_2012()]**: Developed for hardwood species in Spain.
+#' - **[eq_biomass_montero_2005()]**: Developed for 35 Spanish species.
+#' - **[eq_biomass_dieguez_aranda_2009()]**: Developed for 7 Galician species.
+#' - **[eq_biomass_manrique_2017()]**: Developed for *Quercus petraea* and *Quercus pyrenaica*.
+#' - **[eq_biomass_menendez_2022()]**: Developed for young plantations (< 30 years) of 18
+#'   Spanish species. Uses `rcd` (root collar diameter) instead of `diameter`; some species
+#'   require `bp` (biomass packing) instead of `rcd`.
+#' - **[eq_biomass_cudjoe_2024()]**: Developed for *Pinus sylvestris* and *Quercus petraea*
+#'   in Castille and León, Spain.
 #'
 #' Users can check the list of supported species and their corresponding components
 #' in [biomass_models].
@@ -62,52 +77,67 @@ silv_predict_biomass <- function(
     height   = NULL,
     model,
     ntrees = NULL,
+    rcd    = NULL,
+    bp     = NULL,
     quiet  = FALSE) {
 
   # 0. Handle errors and setup
-  ## 0.2. Ensure species has same length as the rest, and ntrees = 1 when ntrees = NULL
+  ## 0.1. Default rcd to diameter if not provided
+  if (is.null(rcd)) rcd <- diameter
+  ## 0.2. Ensure ntrees = 1 when ntrees = NULL
   if (is.null(ntrees)) ntrees <- rep(1, length(diameter))
-  # species <- rep_len(species, length(diameter))
 
   # 1. Define a helper function to calculate biomass for a single tree
-  if (model@equation %in% c(
-    "ruiz-peinado-2011", 
-    "ruiz-peinado-2012")
-  ) {
-
-    ## function to calculate biomass
-    calc_biomass <- function(d, h, n, sp) {
-      ## select expression based on species
-      selected_expr <- model@expression[model@expression$species == sp, ]$expression
-      ## if there are multiple expressions (AGB, BGB)
-      selected_expr <- paste0(
-        "(",
-        paste(selected_expr, collapse = " + "),
-        ")"
+  calc_biomass <- function(d, h, n, sp, rcd_val, bp_val) {
+    ## select expression based on species
+    selected_rows <- model@expression$species == sp
+    selected_expr <- model@expression[selected_rows, ]$expression
+    selected_expr <- selected_expr[!is.na(selected_expr)]
+    if (length(selected_expr) == 0) {
+      cli::cli_abort(
+        "The selected model contains no valid expression for species {.val {sp}}."
       )
-      ##
-      if (grepl("h", selected_expr)) {
-        f1 <- function(d, h) eval(parse(text = selected_expr))
-        biomass <- f1(d, h) * n
-      } else {
-        f2 <- function(d) eval(parse(text = selected_expr))
-        biomass <- f2(d) * n
+    }
+    ## if there are multiple expressions (AGB, BGB)
+    selected_expr <- paste0(
+      "(",
+      paste(selected_expr, collapse = " + "),
+      ")"
+    )
+
+    ## evaluate in a named environment that exposes all possible variable names
+    eval_env <- list(d = d, h = h, rcd = rcd_val, bp = bp_val)
+    biomass   <- eval(parse(text = selected_expr), envir = eval_env) * n
+
+    metric <- biomass
+    if (isTRUE(model@params$return_rmse)) {
+      metric <- model@params$rmse[selected_rows]
+      metric <- metric[!is.na(metric)]
+      if (length(metric) != 1) {
+        cli::cli_abort(
+          "RMSE is only available when the selected species-component combination resolves to a single equation."
+        )
       }
-
-      ## create a table with the outputs
-      biomass_tbl <- data.frame(
-        biomass  = ifelse(model@params$return_rmse, model@params$rmse, biomass),
-        citation = model@url,
-        obs      = model@obs
-      )
-
-      return(biomass_tbl)
+    } else if (isTRUE(model@params$return_r2)) {
+      metric <- model@params$r2[selected_rows]
+      metric <- metric[!is.na(metric)]
+      if (length(metric) != 1) {
+        cli::cli_abort(
+          "R2 is only available when the selected species-component combination resolves to a single equation."
+        )
+      }
     }
 
-  }  
+    data.frame(
+      biomass  = metric,
+      citation = model@url,
+      obs      = model@obs
+    )
+  }
 
   # 2. Vectorize the function to handle multiple inputs
-  biomass_mat <- mapply(calc_biomass, diameter, height, ntrees, model@species)
+  bp_vec  <- if (is.null(bp)) rep(NA_real_, length(diameter)) else bp
+  biomass_mat <- mapply(calc_biomass, diameter, height, ntrees, model@species, rcd, bp_vec)
 
   biomass_df <- biomass_mat |>
     t() |>
@@ -152,15 +182,42 @@ silv_predict_biomass <- function(
 #' @export
 #' 
 #' @details
-#' Users can check the list of supported species and their corresponding components
-#' in [biomass_models].
+#' 
+#' **Supported species (10):**
+#' 
+#' *Abies alba*, *Abies pinsapo*, *Juniperus thurifera*, *Pinus canariensis*,
+#' *Pinus halepensis*, *Pinus nigra*, *Pinus pinaster*, *Pinus pinea*,
+#' *Pinus sylvestris*, *Pinus uncinata*
+#' 
+#' **Available components:**
+#' 
+#' Aboveground / belowground groups (summed automatically):
+#' 
+#' * `"AGB"` — total aboveground biomass
+#' * `"BGB"` — total belowground biomass (roots)
+#' * `"tree"` — total tree biomass (AGB + BGB)
+#' 
+#' Tree structural groups:
+#' 
+#' * `"stem"` — stem wood
+#' * `"branches"` — all branch fractions combined
+#' * `"roots"` — roots (equivalent to BGB)
+#' 
+#' Individual tree components (species availability varies):
+#' 
+#' * `"thick branches"` — branches > 7 cm
+#' * `"thick and medium branches"` — branches > 2 cm
+#' * `"medium branches"` — branches 2–7 cm
+#' * `"small branches and leaves"` — branches < 2 cm including leaves/needles
+#' 
+#' Users can check the full species–component matrix in [biomass_models].
 #' 
 #' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()], [eq_biomass_dieguez_aranda_2009()],
 #' [eq_biomass_ruiz_peinado_2012()], [eq_biomass_manrique_2017()], [eq_biomass_menendez_2022()], [eq_biomass_cudjoe_2024()] 
 #'
 #' @examples
-#' ## get model parameters for silv_predict_biomass
-#' eq_biomass_ruiz_peinado_2011("Pinus pinaster")
+#' ## Aboveground biomass for Pinus pinaster
+#' eq_biomass_ruiz_peinado_2011("Pinus pinaster", "AGB")
 eq_biomass_ruiz_peinado_2011 <- function(species, component = "stem", return_rmse = FALSE) {
 
   # 0. Handle errors 
@@ -230,16 +287,47 @@ eq_biomass_ruiz_peinado_2011 <- function(species, component = "stem", return_rms
 #' @export
 #' 
 #' @details
-#' Users can check the list of supported species and their corresponding components
-#' in [biomass_models].
 #' 
-#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()], [eq_biomass_dieguez_aranda_2009()]
-#' [eq_biomass_ruiz_peinado_2011()], [eq_biomass_manrique_2017()], [eq_biomass_menendez_2022()], 
+#' **Supported species (13):**
+#' 
+#' *Alnus glutinosa*, *Castanea sativa*, *Ceratonia siliqua*, *Eucalyptus globulus*,
+#' *Fagus sylvatica*, *Fraxinus angustifolia*, *Olea europaea*, *Populus x euramericana*,
+#' *Quercus canariensis*, *Quercus faginea*, *Quercus ilex*, *Quercus pyrenaica*,
+#' *Quercus suber*
+#' 
+#' **Available components:**
+#' 
+#' Aboveground / belowground groups (summed automatically):
+#' 
+#' * `"AGB"` — total aboveground biomass
+#' * `"BGB"` — total belowground biomass (roots)
+#' * `"tree"` — total tree biomass (AGB + BGB)
+#' 
+#' Tree structural groups:
+#' 
+#' * `"stem"` — stem wood
+#' * `"branches"` — all branch fractions combined
+#' * `"roots"` — roots (equivalent to BGB)
+#' 
+#' Individual tree components (species availability varies):
+#' 
+#' * `"stem and thick branches"` — stem together with branches > 7 cm
+#' * `"thick branches"` — branches > 7 cm
+#' * `"thick and medium branches"` — branches > 2 cm
+#' * `"medium branches"` — branches 2–7 cm
+#' * `"small branches"` — branches 0.5–2 cm
+#' * `"small branches and leaves"` — branches < 2 cm including leaves
+#' * `"medium branches, small branches and leaves"` — branches < 7 cm including leaves
+#' 
+#' Users can check the full species–component matrix in [biomass_models].
+#' 
+#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()], [eq_biomass_dieguez_aranda_2009()],
+#' [eq_biomass_ruiz_peinado_2011()], [eq_biomass_manrique_2017()], [eq_biomass_menendez_2022()],
 #' [eq_biomass_cudjoe_2024()] 
 #'
 #' @examples
-#' ## get model parameters for silv_predict_biomass
-#' eq_biomass_ruiz_peinado_2012("Quercus suber")
+#' ## Aboveground biomass for Quercus suber
+#' eq_biomass_ruiz_peinado_2012("Quercus suber", "AGB")
 eq_biomass_ruiz_peinado_2012 <- function(species, component = "stem", return_rmse = FALSE) {
 
   # 0. Handle errors 
@@ -313,36 +401,43 @@ eq_biomass_ruiz_peinado_2012 <- function(species, component = "stem", return_rms
 #' 
 #' @details
 #' 
-#' There are seven species included in this model: *Pinus pinaster, Pinaster radiata, Pinus*
-#' *sylvestris, Eucalyptus globulus, Eucalyptus nitens, Quercus robur*, and *Betula alba*
+#' **Supported species (7):**
 #' 
-#' The tree components are divided into groups, and any of them can be introduced in the
-#' component argument:
+#' *Betula alba*, *Eucalyptus globulus*, *Eucalyptus nitens*, *Pinus pinaster*,
+#' *Pinus radiata*, *Pinus sylvestris*, *Quercus robur*
 #' 
-#' * **AGB**: all aboveground biomass components
-#' * **BGB**: all belowground biomass compoponents
-#' * **tree**: total tree biomass includying AGB and BGB
+#' **Available components:**
 #' 
-#' Then we have the second group of components, which are related to tree groups:
+#' Aboveground / belowground groups (summed automatically):
 #' 
-#' * **stem**: includes the stem and bark
-#' * **branches**: includes all branches
-#' * **roots**: includes the roots (same as BGB)
+#' * `"AGB"` — total aboveground biomass
+#' * `"BGB"` — total belowground biomass (roots)
 #' 
-#' Finally, we have the last level, which includes tree components (not all of them
-#' are available for all species): stem, bark, thick branches (>7cm), medium branches (2-7cm), 
-#' thin branches (0.5-2cm), twigs (<0.5cm), dry branches, leaves, roots. In some species,
-#' there's "stem and thick branches", instead of two groups.
+#' Tree structural groups:
 #' 
-#' Users can check the list of supported species and their corresponding components
-#' in [biomass_models].
+#' * `"stem"` — stem fraction(s)
+#' * `"branches"` — all branch fractions combined
+#' * `"roots"` — roots (equivalent to BGB)
+#' 
+#' Individual tree components (species availability varies):
+#' 
+#' * `"stem and thick branches"` — stem together with thickest branches
+#' * `"thick branches"` — branches > 7 cm
+#' * `"medium branches"` — branches 2–7 cm
+#' * `"small branches"` — branches 0.5–2 cm
+#' * `"twigs"` — branches < 0.5 cm
+#' * `"dry branches"` — dead attached branches
+#' * `"leaves"` — foliage (including needles)
+#' * `"roots"` — coarse roots
+#' 
+#' Users can check the full species–component matrix in [biomass_models].
 #' 
 #' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()],
 #' [eq_biomass_ruiz_peinado_2011()], [eq_biomass_ruiz_peinado_2012()], [eq_biomass_manrique_2017()], 
 #' [eq_biomass_menendez_2022()], [eq_biomass_cudjoe_2024()] 
 #'
 #' @examples
-#' ## get model parameters for silv_predict_biomass
+#' ## Aboveground biomass for Pinus pinaster
 #' eq_biomass_dieguez_aranda_2009("Pinus pinaster", "AGB")
 eq_biomass_dieguez_aranda_2009 <- function(species, component = "stem", return_r2 = FALSE, return_rmse = FALSE) {
 
@@ -417,35 +512,49 @@ eq_biomass_dieguez_aranda_2009 <- function(species, component = "stem", return_r
 #' 
 #' @details
 #' 
-#' There are 35 species included in the model.
+#' **Supported species (35):**
 #' 
-#' The tree components are divided into groups, and any of them can be introduced in the
-#' component argument:
+#' *Abies alba*, *Abies pinsapo*, *Alnus glutinosa*, *Betula* spp., *Castanea sativa*,
+#' *Ceratonia siliqua*, *Erica arborea*, *Eucalyptus* spp., *Fagus sylvatica*,
+#' *Fraxinus* spp., *Ilex canariensis*, *Juniperus oxycedrus*, *Juniperus phoenicea*,
+#' *Juniperus thurifera*, *Laurus azorica*, *Myrica faya*, *Olea europaea* var. *sylvestris*,
+#' *Other broadleaves*, *Other conifers*, *Other laurel species*, *Pinus canariensis*,
+#' *Pinus halepensis*, *Pinus nigra*, *Pinus pinaster*, *Pinus pinea*, *Pinus radiata*,
+#' *Pinus sylvestris*, *Pinus uncinata*, *Populus x euramericana*, *Quercus canariensis*,
+#' *Quercus faginea*, *Quercus ilex*, *Quercus pyrenaica*, *Quercus robur*, *Quercus suber*
 #' 
-#' * **AGB**: all aboveground biomass components
-#' * **BGB**: all belowground biomass compoponents
-#' * **tree** or **all**: total tree biomass includying AGB and BGB
+#' **Available components:**
 #' 
-#' Then we have the second group of components, which are related to tree groups:
+#' Aboveground / belowground groups (summed automatically):
 #' 
-#' * **stem**: includes the stem and bark
-#' * **branches**: includes all branches
-#' * **roots**: includes the roots (same as BGB)
+#' * `"AGB"` — total aboveground biomass
+#' * `"BGB"` — total belowground biomass (roots)
+#' * `"all"` or `"tree"` — total tree biomass (AGB + BGB)
 #' 
-#' Finally, we have the last level, which includes tree components (not all of them
-#' are available for all species): stem, bark, thick branches (>7cm), medium branches (2-7cm), 
-#' thin branches (0.5-2cm), leaves (include needles), roots. In some species,
-#' there's "stem and thick branches", instead of two groups.
+#' Tree structural groups:
 #' 
-#' Users can check the list of supported species and their corresponding components
-#' in [biomass_models].
+#' * `"stem"` — stem fraction(s)
+#' * `"branches"` — all branch fractions combined
+#' * `"roots"` — roots (equivalent to BGB)
 #' 
-#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_dieguez_aranda_2009()]
+#' Individual tree components (species availability varies):
+#' 
+#' * `"stem"` — stem wood
+#' * `"stem and thick branches"` — stem together with branches > 7 cm
+#' * `"thick branches"` — branches > 7 cm
+#' * `"medium branches"` — branches 2–7 cm
+#' * `"small branches"` — branches < 2 cm
+#' * `"leaves"` — foliage (including needles)
+#' * `"roots"` — coarse roots
+#' 
+#' Users can check the full species–component matrix in [biomass_models].
+#' 
+#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_dieguez_aranda_2009()],
 #' [eq_biomass_ruiz_peinado_2011()], [eq_biomass_ruiz_peinado_2012()], [eq_biomass_manrique_2017()], 
 #' [eq_biomass_menendez_2022()], [eq_biomass_cudjoe_2024()] 
 #'
 #' @examples
-#' ## get model parameters for silv_predict_biomass
+#' ## Aboveground biomass for Pinus pinaster
 #' eq_biomass_montero_2005("Pinus pinaster", "AGB")
 eq_biomass_montero_2005 <- function(species, component = "stem", return_r2 = FALSE) {
 
@@ -521,21 +630,31 @@ eq_biomass_montero_2005 <- function(species, component = "stem", return_r2 = FAL
 #' 
 #' @details
 #' 
-#' There are two species in this model: *Quercus petraea* and *Quercus pyrenaica* 
+#' **Supported species (2):**
 #' 
-#' The tree components include:
+#' * *Quercus petraea*
+#' * *Quercus pyrenaica*
 #' 
-#' * **stem**: includes stem and the thickest branches
-#' * **medium branches**
-#' * **thin branches**
-#' * **AGB**: total biomass, results of summing the previous three components
+#' **Available components:**
 #' 
-#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()], [eq_biomass_dieguez_aranda_2009()]
+#' Aboveground group (summed automatically):
+#' 
+#' * `"AGB"` — total aboveground biomass (sum of all components below)
+#' 
+#' Individual tree components:
+#' 
+#' * `"stem and thick branches"` — stem together with branches > 7 cm
+#' * `"medium branches"` — branches 2–7 cm
+#' * `"small branches"` — branches < 2 cm
+#' 
+#' Users can check the full species–component matrix in [biomass_models].
+#' 
+#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()], [eq_biomass_dieguez_aranda_2009()],
 #' [eq_biomass_ruiz_peinado_2011()], [eq_biomass_ruiz_peinado_2012()], [eq_biomass_menendez_2022()], 
 #' [eq_biomass_cudjoe_2024()] 
 #'
 #' @examples
-#' ## get model parameters for silv_predict_biomass
+#' ## Aboveground biomass for Quercus petraea
 #' eq_biomass_manrique_2017("Quercus petraea", "AGB")
 eq_biomass_manrique_2017 <- function(species, component = "AGB", return_r2 = FALSE, return_rmse = FALSE) {
 
@@ -611,17 +730,43 @@ eq_biomass_manrique_2017 <- function(species, component = "AGB", return_r2 = FAL
 #' 
 #' @details
 #' 
-#' There are 15 species in this model, including generic equations for *Conifers*, 
-#' *Deciduous broadleaves*, and *Evergreen broadleaves*.
+#' **Supported species (18):**
 #' 
-#' All the models measure only aboveground biomass.
+#' *Betula* sp., *Fagus sylvatica*, *Juniperus thurifera*, *Pinus halepensis*,
+#' *Pinus nigra*, *Pinus pinaster*, *Pinus pinea*, *Pinus radiata*, *Pinus sylvestris*,
+#' *Quercus faginea*, *Quercus ilex*, *Quercus petraea*, *Quercus pyrenaica*,
+#' *Quercus robur*, *Quercus suber*
 #' 
-#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()], [eq_biomass_dieguez_aranda_2009()]
+#' Generic equations are also available for functional groups:
+#' 
+#' * `"Conifers"` — generic equation for conifer species
+#' * `"Deciduous broadleaves"` — generic equation for deciduous broadleaf species
+#' * `"Evergreen broadleaves"` — generic equation for evergreen broadleaf species
+#' 
+#' **Available components:**
+#' 
+#' * `"AGB"` — aboveground biomass (only component available; no `component` argument needed)
+#' 
+#' **Important — non-standard input variables:**
+#' 
+#' Unlike other biomass models, these equations were fitted on **young plantations
+#' (< 30 years)** and use different predictor variables:
+#' 
+#' * Most species use `rcd` = root collar diameter (cm), **not** diameter at breast
+#'   height. Pass it via the `rcd` argument of [silv_predict_biomass()].
+#' * Some species (*Pinus halepensis*, *Pinus nigra*, *Quercus suber*,
+#'   *Evergreen broadleaves*) use `bp` = biomass packing (m\ifelse{html}{\out{<sup>3</sup>}}{$^3$}). Pass it via the
+#'   `bp` argument of [silv_predict_biomass()].
+#' * *Betula* sp. uses only `h` (total height).
+#' 
+#' Users can check the full species–component matrix in [biomass_models].
+#' 
+#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()], [eq_biomass_dieguez_aranda_2009()],
 #' [eq_biomass_ruiz_peinado_2011()], [eq_biomass_ruiz_peinado_2012()], [eq_biomass_manrique_2017()], 
 #' [eq_biomass_cudjoe_2024()] 
 #'
 #' @examples
-#' ## get model parameters for silv_predict_biomass
+#' ## AGB for Fagus sylvatica using root collar diameter
 #' eq_biomass_menendez_2022("Fagus sylvatica")
 eq_biomass_menendez_2022 <- function(species, return_r2 = FALSE, return_rmse = FALSE) {
 
@@ -680,28 +825,33 @@ eq_biomass_menendez_2022 <- function(species, return_r2 = FALSE, return_rmse = F
 #' 
 #' @details
 #' 
-#' There are three species options in this model:
+#' **Supported species (3):**
 #' 
-#' * ***Quercus petraea***
+#' * *Pinus sylvestris*
+#' * *Quercus petraea*
+#' * `"mixed"` — mixed stand of *Pinus sylvestris* × *Quercus petraea*
 #' 
-#' * ***Pinus sylvestris***
+#' **Available components:**
 #' 
-#' * **Mixed**: stands with *Quercus petraea* and *Pinus sylvestris*
+#' Aboveground group (summed automatically):
 #' 
-#' The tree components include some AGB components:
+#' * `"AGB"` — total aboveground biomass (sum of all components below)
 #' 
-#' * **leaves**: only for *P. sylvestris*
-#' * **stem**: for all species
-#' * **medium branches and small brances**: for all species
-#' * **thick branches**: for all species
-#' * **AGB**: total biomass, results of summing the previous components
+#' Individual tree components (species availability varies):
 #' 
-#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()], [eq_biomass_dieguez_aranda_2009()]
+#' * `"stem"` — stem wood (all species)
+#' * `"thick branches"` — branches > 7 cm (all species)
+#' * `"medium branches and small branches"` — branches < 7 cm (all species)
+#' * `"leaves"` — foliage/needles (*Pinus sylvestris* only)
+#' 
+#' Users can check the full species–component matrix in [biomass_models].
+#' 
+#' @seealso [silv_predict_biomass()], [biomass_models], [eq_biomass_montero_2005()], [eq_biomass_dieguez_aranda_2009()],
 #' [eq_biomass_ruiz_peinado_2011()], [eq_biomass_ruiz_peinado_2012()], [eq_biomass_manrique_2017()],
 #' [eq_biomass_menendez_2022()]
 #'
 #' @examples
-#' ## get model parameters for silv_predict_biomass
+#' ## Aboveground biomass for a mixed stand
 #' eq_biomass_cudjoe_2024("mixed", "AGB")
 eq_biomass_cudjoe_2024 <- function(species, component = "AGB", return_rmse = FALSE) {
 
@@ -733,7 +883,7 @@ eq_biomass_cudjoe_2024 <- function(species, component = "AGB", return_rmse = FAL
 
   # 2. Return
   ModelBiomass(
-    equation   = "cudjoe-2017",
+    equation   = "cudjoe-2024",
     species    = species,
     component  = component,
     expression = data.frame(

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ common silvicultural analysis. It aims to support forest management and
 research by providing a flexible toolkit for data manipulation and
 summary.
 
+### Suggested companion reading
+
+If you want a visual overview before diving into the API, use the
+supporting poster:
+
+- [Poster on R silviculture workflows](https://doi.org/10.13140/RG.2.2.28098.75205)
+
 ## Installation
 
 You can install the development version of `silviculture` from

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ summary.
 If you want a visual overview before diving into the API, use the
 supporting poster:
 
-- [Poster on R silviculture workflows](https://doi.org/10.13140/RG.2.2.28098.75205)
+- [Poster on R silviculture](https://doi.org/10.13140/RG.2.2.28098.75205)
 
 ## Installation
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -93,6 +93,7 @@ reference:
     desc: Datasets included in the package
     contents:
     - biomass_models
+    - carbon_models
     - inventory_samples
 
   - title: Objects

--- a/inst/references.bib
+++ b/inst/references.bib
@@ -140,7 +140,7 @@
 }
 
 @misc{vazquez-veloso_poster_2025,
-	author = {Vázquez-Veloso, Aitor},
+	author = {Cidre-González, Adrián and Vázquez-Veloso, Aitor},
 	title = {silviculture: {An} {R} Package for {Forest} {Inventory} and {Silvicultural} {Workflows}},
 	year = {2025},
 	doi = {10.13140/RG.2.2.28098.75205},

--- a/inst/references.bib
+++ b/inst/references.bib
@@ -105,7 +105,6 @@
 	pages = {122981},
 }
 
-<<<<<<< HEAD
 
 @article{menendez-miguelez_species-specific_2022,
 	title = {Species-specific and generalized biomass models for estimating carbon stocks of young reforestations},
@@ -138,17 +137,12 @@
 	year = {2024},
 	keywords = {Pinus sylvestris, Tree allometry, Species mixture, Quercus petraea, Biomass equations, Dirichlet regression, Pine-oak mixed stand},
 	pages = {176061},
-=======
-@article{palahi_individual-tree_2003,
-	title = {Individual-tree growth and mortality models for {Scots} pine (\textit{{Pinus} sylvestris} {L}.) in north-east {Spain}},
-	volume = {60},
-	url = {https://www.afs-journal.org/articles/forest/pdf/2003/01/F3101.pdf},
-	number = {1},
-	journal = {Annals of Forest Science},
-	author = {Palahí, Marc and Pukkala, Timo and Miina, Jari and Montero, Gregorio},
-	year = {2003},
-	note = {Publisher: EDP Sciences},
-	keywords = {Pinus sylvestris},
-	pages = {1--10},
->>>>>>> ed07048169f72c5136e72eea26506076f320a24a
+}
+
+@misc{vazquez-veloso_poster_2025,
+	author = {Vázquez-Veloso, Aitor},
+	title = {silviculture: {An} {R} Package for {Forest} {Inventory} and {Silvicultural} {Workflows}},
+	year = {2025},
+	doi = {10.13140/RG.2.2.28098.75205},
+	howpublished = {Poster, ResearchGate},
 }

--- a/man/eq_biomass_cudjoe_2024.Rd
+++ b/man/eq_biomass_cudjoe_2024.Rd
@@ -25,28 +25,36 @@ Allometric equations adjusted for \emph{Quercus petraea}, and \emph{Pinus sylves
 in Castille and León (Spain)
 }
 \details{
-There are three species options in this model:
+\strong{Supported species (3):}
 \itemize{
-\item \emph{\strong{Quercus petraea}}
-\item \emph{\strong{Pinus sylvestris}}
-\item \strong{Mixed}: stands with \emph{Quercus petraea} and \emph{Pinus sylvestris}
+\item \emph{Pinus sylvestris}
+\item \emph{Quercus petraea}
+\item \code{"mixed"} — mixed stand of \emph{Pinus sylvestris} × \emph{Quercus petraea}
 }
 
-The tree components include some AGB components:
+\strong{Available components:}
+
+Aboveground group (summed automatically):
 \itemize{
-\item \strong{leaves}: only for \emph{P. sylvestris}
-\item \strong{stem}: for all species
-\item \strong{medium branches and small brances}: for all species
-\item \strong{thick branches}: for all species
-\item \strong{AGB}: total biomass, results of summing the previous components
+\item \code{"AGB"} — total aboveground biomass (sum of all components below)
 }
+
+Individual tree components (species availability varies):
+\itemize{
+\item \code{"stem"} — stem wood (all species)
+\item \code{"thick branches"} — branches > 7 cm (all species)
+\item \code{"medium branches and small branches"} — branches < 7 cm (all species)
+\item \code{"leaves"} — foliage/needles (\emph{Pinus sylvestris} only)
+}
+
+Users can check the full species–component matrix in \link{biomass_models}.
 }
 \examples{
-## get model parameters for silv_predict_biomass
+## Aboveground biomass for a mixed stand
 eq_biomass_cudjoe_2024("mixed", "AGB")
 }
 \seealso{
-\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}}
+\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}},
 \code{\link[=eq_biomass_ruiz_peinado_2011]{eq_biomass_ruiz_peinado_2011()}}, \code{\link[=eq_biomass_ruiz_peinado_2012]{eq_biomass_ruiz_peinado_2012()}}, \code{\link[=eq_biomass_manrique_2017]{eq_biomass_manrique_2017()}},
 \code{\link[=eq_biomass_menendez_2022]{eq_biomass_menendez_2022()}}
 }

--- a/man/eq_biomass_dieguez_aranda_2009.Rd
+++ b/man/eq_biomass_dieguez_aranda_2009.Rd
@@ -32,34 +32,42 @@ A S7 list of parameters
 Allometric equations adjusted for Galician (Spain) species
 }
 \details{
-There are seven species included in this model: \emph{Pinus pinaster, Pinaster radiata, Pinus}
-\emph{sylvestris, Eucalyptus globulus, Eucalyptus nitens, Quercus robur}, and \emph{Betula alba}
+\strong{Supported species (7):}
 
-The tree components are divided into groups, and any of them can be introduced in the
-component argument:
+\emph{Betula alba}, \emph{Eucalyptus globulus}, \emph{Eucalyptus nitens}, \emph{Pinus pinaster},
+\emph{Pinus radiata}, \emph{Pinus sylvestris}, \emph{Quercus robur}
+
+\strong{Available components:}
+
+Aboveground / belowground groups (summed automatically):
 \itemize{
-\item \strong{AGB}: all aboveground biomass components
-\item \strong{BGB}: all belowground biomass compoponents
-\item \strong{tree}: total tree biomass includying AGB and BGB
+\item \code{"AGB"} — total aboveground biomass
+\item \code{"BGB"} — total belowground biomass (roots)
 }
 
-Then we have the second group of components, which are related to tree groups:
+Tree structural groups:
 \itemize{
-\item \strong{stem}: includes the stem and bark
-\item \strong{branches}: includes all branches
-\item \strong{roots}: includes the roots (same as BGB)
+\item \code{"stem"} — stem fraction(s)
+\item \code{"branches"} — all branch fractions combined
+\item \code{"roots"} — roots (equivalent to BGB)
 }
 
-Finally, we have the last level, which includes tree components (not all of them
-are available for all species): stem, bark, thick branches (>7cm), medium branches (2-7cm),
-thin branches (0.5-2cm), twigs (<0.5cm), dry branches, leaves, roots. In some species,
-there's "stem and thick branches", instead of two groups.
+Individual tree components (species availability varies):
+\itemize{
+\item \code{"stem and thick branches"} — stem together with thickest branches
+\item \code{"thick branches"} — branches > 7 cm
+\item \code{"medium branches"} — branches 2–7 cm
+\item \code{"small branches"} — branches 0.5–2 cm
+\item \code{"twigs"} — branches < 0.5 cm
+\item \code{"dry branches"} — dead attached branches
+\item \code{"leaves"} — foliage (including needles)
+\item \code{"roots"} — coarse roots
+}
 
-Users can check the list of supported species and their corresponding components
-in \link{biomass_models}.
+Users can check the full species–component matrix in \link{biomass_models}.
 }
 \examples{
-## get model parameters for silv_predict_biomass
+## Aboveground biomass for Pinus pinaster
 eq_biomass_dieguez_aranda_2009("Pinus pinaster", "AGB")
 }
 \seealso{

--- a/man/eq_biomass_manrique_2017.Rd
+++ b/man/eq_biomass_manrique_2017.Rd
@@ -33,22 +33,34 @@ Allometric equations adjusted for \emph{Quercus petraea} and \emph{Quercus pyren
 in Palencia, Spain
 }
 \details{
-There are two species in this model: \emph{Quercus petraea} and \emph{Quercus pyrenaica}
-
-The tree components include:
+\strong{Supported species (2):}
 \itemize{
-\item \strong{stem}: includes stem and the thickest branches
-\item \strong{medium branches}
-\item \strong{thin branches}
-\item \strong{AGB}: total biomass, results of summing the previous three components
+\item \emph{Quercus petraea}
+\item \emph{Quercus pyrenaica}
 }
+
+\strong{Available components:}
+
+Aboveground group (summed automatically):
+\itemize{
+\item \code{"AGB"} — total aboveground biomass (sum of all components below)
+}
+
+Individual tree components:
+\itemize{
+\item \code{"stem and thick branches"} — stem together with branches > 7 cm
+\item \code{"medium branches"} — branches 2–7 cm
+\item \code{"small branches"} — branches < 2 cm
+}
+
+Users can check the full species–component matrix in \link{biomass_models}.
 }
 \examples{
-## get model parameters for silv_predict_biomass
+## Aboveground biomass for Quercus petraea
 eq_biomass_manrique_2017("Quercus petraea", "AGB")
 }
 \seealso{
-\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}}
+\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}},
 \code{\link[=eq_biomass_ruiz_peinado_2011]{eq_biomass_ruiz_peinado_2011()}}, \code{\link[=eq_biomass_ruiz_peinado_2012]{eq_biomass_ruiz_peinado_2012()}}, \code{\link[=eq_biomass_menendez_2022]{eq_biomass_menendez_2022()}},
 \code{\link[=eq_biomass_cudjoe_2024]{eq_biomass_cudjoe_2024()}}
 }

--- a/man/eq_biomass_menendez_2022.Rd
+++ b/man/eq_biomass_menendez_2022.Rd
@@ -25,17 +25,46 @@ Allometric equations for young (<30) plantations of 18 Spanish species including
 broadleaf and conifer species. Only aboveground biomass.
 }
 \details{
-There are 15 species in this model, including generic equations for \emph{Conifers},
-\emph{Deciduous broadleaves}, and \emph{Evergreen broadleaves}.
+\strong{Supported species (18):}
 
-All the models measure only aboveground biomass.
+\emph{Betula} sp., \emph{Fagus sylvatica}, \emph{Juniperus thurifera}, \emph{Pinus halepensis},
+\emph{Pinus nigra}, \emph{Pinus pinaster}, \emph{Pinus pinea}, \emph{Pinus radiata}, \emph{Pinus sylvestris},
+\emph{Quercus faginea}, \emph{Quercus ilex}, \emph{Quercus petraea}, \emph{Quercus pyrenaica},
+\emph{Quercus robur}, \emph{Quercus suber}
+
+Generic equations are also available for functional groups:
+\itemize{
+\item \code{"Conifers"} — generic equation for conifer species
+\item \code{"Deciduous broadleaves"} — generic equation for deciduous broadleaf species
+\item \code{"Evergreen broadleaves"} — generic equation for evergreen broadleaf species
+}
+
+\strong{Available components:}
+\itemize{
+\item \code{"AGB"} — aboveground biomass (only component available; no \code{component} argument needed)
+}
+
+\strong{Important — non-standard input variables:}
+
+Unlike other biomass models, these equations were fitted on \strong{young plantations
+(< 30 years)} and use different predictor variables:
+\itemize{
+\item Most species use \code{rcd} = root collar diameter (cm), \strong{not} diameter at breast
+height. Pass it via the \code{rcd} argument of \code{\link[=silv_predict_biomass]{silv_predict_biomass()}}.
+\item Some species (\emph{Pinus halepensis}, \emph{Pinus nigra}, \emph{Quercus suber},
+\emph{Evergreen broadleaves}) use \code{bp} = biomass packing (m\ifelse{html}{\out{<sup>3</sup>}}{$^3$}). Pass it via the
+\code{bp} argument of \code{\link[=silv_predict_biomass]{silv_predict_biomass()}}.
+\item \emph{Betula} sp. uses only \code{h} (total height).
+}
+
+Users can check the full species–component matrix in \link{biomass_models}.
 }
 \examples{
-## get model parameters for silv_predict_biomass
+## AGB for Fagus sylvatica using root collar diameter
 eq_biomass_menendez_2022("Fagus sylvatica")
 }
 \seealso{
-\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}}
+\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}},
 \code{\link[=eq_biomass_ruiz_peinado_2011]{eq_biomass_ruiz_peinado_2011()}}, \code{\link[=eq_biomass_ruiz_peinado_2012]{eq_biomass_ruiz_peinado_2012()}}, \code{\link[=eq_biomass_manrique_2017]{eq_biomass_manrique_2017()}},
 \code{\link[=eq_biomass_cudjoe_2024]{eq_biomass_cudjoe_2024()}}
 }

--- a/man/eq_biomass_montero_2005.Rd
+++ b/man/eq_biomass_montero_2005.Rd
@@ -24,37 +24,52 @@ A S7 list of parameters
 Allometric equations adjusted for Spanish species
 }
 \details{
-There are 35 species included in the model.
+\strong{Supported species (35):}
 
-The tree components are divided into groups, and any of them can be introduced in the
-component argument:
+\emph{Abies alba}, \emph{Abies pinsapo}, \emph{Alnus glutinosa}, \emph{Betula} spp., \emph{Castanea sativa},
+\emph{Ceratonia siliqua}, \emph{Erica arborea}, \emph{Eucalyptus} spp., \emph{Fagus sylvatica},
+\emph{Fraxinus} spp., \emph{Ilex canariensis}, \emph{Juniperus oxycedrus}, \emph{Juniperus phoenicea},
+\emph{Juniperus thurifera}, \emph{Laurus azorica}, \emph{Myrica faya}, \emph{Olea europaea} var. \emph{sylvestris},
+\emph{Other broadleaves}, \emph{Other conifers}, \emph{Other laurel species}, \emph{Pinus canariensis},
+\emph{Pinus halepensis}, \emph{Pinus nigra}, \emph{Pinus pinaster}, \emph{Pinus pinea}, \emph{Pinus radiata},
+\emph{Pinus sylvestris}, \emph{Pinus uncinata}, \emph{Populus x euramericana}, \emph{Quercus canariensis},
+\emph{Quercus faginea}, \emph{Quercus ilex}, \emph{Quercus pyrenaica}, \emph{Quercus robur}, \emph{Quercus suber}
+
+\strong{Available components:}
+
+Aboveground / belowground groups (summed automatically):
 \itemize{
-\item \strong{AGB}: all aboveground biomass components
-\item \strong{BGB}: all belowground biomass compoponents
-\item \strong{tree} or \strong{all}: total tree biomass includying AGB and BGB
+\item \code{"AGB"} — total aboveground biomass
+\item \code{"BGB"} — total belowground biomass (roots)
+\item \code{"all"} or \code{"tree"} — total tree biomass (AGB + BGB)
 }
 
-Then we have the second group of components, which are related to tree groups:
+Tree structural groups:
 \itemize{
-\item \strong{stem}: includes the stem and bark
-\item \strong{branches}: includes all branches
-\item \strong{roots}: includes the roots (same as BGB)
+\item \code{"stem"} — stem fraction(s)
+\item \code{"branches"} — all branch fractions combined
+\item \code{"roots"} — roots (equivalent to BGB)
 }
 
-Finally, we have the last level, which includes tree components (not all of them
-are available for all species): stem, bark, thick branches (>7cm), medium branches (2-7cm),
-thin branches (0.5-2cm), leaves (include needles), roots. In some species,
-there's "stem and thick branches", instead of two groups.
+Individual tree components (species availability varies):
+\itemize{
+\item \code{"stem"} — stem wood
+\item \code{"stem and thick branches"} — stem together with branches > 7 cm
+\item \code{"thick branches"} — branches > 7 cm
+\item \code{"medium branches"} — branches 2–7 cm
+\item \code{"small branches"} — branches < 2 cm
+\item \code{"leaves"} — foliage (including needles)
+\item \code{"roots"} — coarse roots
+}
 
-Users can check the list of supported species and their corresponding components
-in \link{biomass_models}.
+Users can check the full species–component matrix in \link{biomass_models}.
 }
 \examples{
-## get model parameters for silv_predict_biomass
+## Aboveground biomass for Pinus pinaster
 eq_biomass_montero_2005("Pinus pinaster", "AGB")
 }
 \seealso{
-\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}}
+\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}},
 \code{\link[=eq_biomass_ruiz_peinado_2011]{eq_biomass_ruiz_peinado_2011()}}, \code{\link[=eq_biomass_ruiz_peinado_2012]{eq_biomass_ruiz_peinado_2012()}}, \code{\link[=eq_biomass_manrique_2017]{eq_biomass_manrique_2017()}},
 \code{\link[=eq_biomass_menendez_2022]{eq_biomass_menendez_2022()}}, \code{\link[=eq_biomass_cudjoe_2024]{eq_biomass_cudjoe_2024()}}
 }

--- a/man/eq_biomass_ruiz_peinado_2011.Rd
+++ b/man/eq_biomass_ruiz_peinado_2011.Rd
@@ -24,12 +24,41 @@ A S7 list of parameters
 Allometric equations adjusted for Spanish softwood species
 }
 \details{
-Users can check the list of supported species and their corresponding components
-in \link{biomass_models}.
+\strong{Supported species (10):}
+
+\emph{Abies alba}, \emph{Abies pinsapo}, \emph{Juniperus thurifera}, \emph{Pinus canariensis},
+\emph{Pinus halepensis}, \emph{Pinus nigra}, \emph{Pinus pinaster}, \emph{Pinus pinea},
+\emph{Pinus sylvestris}, \emph{Pinus uncinata}
+
+\strong{Available components:}
+
+Aboveground / belowground groups (summed automatically):
+\itemize{
+\item \code{"AGB"} — total aboveground biomass
+\item \code{"BGB"} — total belowground biomass (roots)
+\item \code{"tree"} — total tree biomass (AGB + BGB)
+}
+
+Tree structural groups:
+\itemize{
+\item \code{"stem"} — stem wood
+\item \code{"branches"} — all branch fractions combined
+\item \code{"roots"} — roots (equivalent to BGB)
+}
+
+Individual tree components (species availability varies):
+\itemize{
+\item \code{"thick branches"} — branches > 7 cm
+\item \code{"thick and medium branches"} — branches > 2 cm
+\item \code{"medium branches"} — branches 2–7 cm
+\item \code{"small branches and leaves"} — branches < 2 cm including leaves/needles
+}
+
+Users can check the full species–component matrix in \link{biomass_models}.
 }
 \examples{
-## get model parameters for silv_predict_biomass
-eq_biomass_ruiz_peinado_2011("Pinus pinaster")
+## Aboveground biomass for Pinus pinaster
+eq_biomass_ruiz_peinado_2011("Pinus pinaster", "AGB")
 }
 \seealso{
 \code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}},

--- a/man/eq_biomass_ruiz_peinado_2012.Rd
+++ b/man/eq_biomass_ruiz_peinado_2012.Rd
@@ -24,15 +24,48 @@ A S7 list of parameters
 Allometric equations adjusted for Spanish hardwood species
 }
 \details{
-Users can check the list of supported species and their corresponding components
-in \link{biomass_models}.
+\strong{Supported species (13):}
+
+\emph{Alnus glutinosa}, \emph{Castanea sativa}, \emph{Ceratonia siliqua}, \emph{Eucalyptus globulus},
+\emph{Fagus sylvatica}, \emph{Fraxinus angustifolia}, \emph{Olea europaea}, \emph{Populus x euramericana},
+\emph{Quercus canariensis}, \emph{Quercus faginea}, \emph{Quercus ilex}, \emph{Quercus pyrenaica},
+\emph{Quercus suber}
+
+\strong{Available components:}
+
+Aboveground / belowground groups (summed automatically):
+\itemize{
+\item \code{"AGB"} — total aboveground biomass
+\item \code{"BGB"} — total belowground biomass (roots)
+\item \code{"tree"} — total tree biomass (AGB + BGB)
+}
+
+Tree structural groups:
+\itemize{
+\item \code{"stem"} — stem wood
+\item \code{"branches"} — all branch fractions combined
+\item \code{"roots"} — roots (equivalent to BGB)
+}
+
+Individual tree components (species availability varies):
+\itemize{
+\item \code{"stem and thick branches"} — stem together with branches > 7 cm
+\item \code{"thick branches"} — branches > 7 cm
+\item \code{"thick and medium branches"} — branches > 2 cm
+\item \code{"medium branches"} — branches 2–7 cm
+\item \code{"small branches"} — branches 0.5–2 cm
+\item \code{"small branches and leaves"} — branches < 2 cm including leaves
+\item \code{"medium branches, small branches and leaves"} — branches < 7 cm including leaves
+}
+
+Users can check the full species–component matrix in \link{biomass_models}.
 }
 \examples{
-## get model parameters for silv_predict_biomass
-eq_biomass_ruiz_peinado_2012("Quercus suber")
+## Aboveground biomass for Quercus suber
+eq_biomass_ruiz_peinado_2012("Quercus suber", "AGB")
 }
 \seealso{
-\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}}
+\code{\link[=silv_predict_biomass]{silv_predict_biomass()}}, \link{biomass_models}, \code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}, \code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}},
 \code{\link[=eq_biomass_ruiz_peinado_2011]{eq_biomass_ruiz_peinado_2011()}}, \code{\link[=eq_biomass_manrique_2017]{eq_biomass_manrique_2017()}}, \code{\link[=eq_biomass_menendez_2022]{eq_biomass_menendez_2022()}},
 \code{\link[=eq_biomass_cudjoe_2024]{eq_biomass_cudjoe_2024()}}
 }

--- a/man/silv_predict_biomass.Rd
+++ b/man/silv_predict_biomass.Rd
@@ -9,11 +9,13 @@ silv_predict_biomass(
   height = NULL,
   model,
   ntrees = NULL,
+  rcd = NULL,
+  bp = NULL,
   quiet = FALSE
 )
 }
 \arguments{
-\item{diameter}{A numeric vector of tree diameters (in cm).}
+\item{diameter}{A numeric vector of tree diameters at breast height (in cm).}
 
 \item{height}{A numeric vector of tree heights (in m).}
 
@@ -22,6 +24,15 @@ additional arguments depending on the model used.}
 
 \item{ntrees}{An optional numeric value indicating the number of trees in
 this diameter-height class. Defaults to 1 if \code{NULL}.}
+
+\item{rcd}{An optional numeric vector of root collar diameters (in cm). Required
+for \code{\link{eq_biomass_menendez_2022}}, which uses root collar diameter
+instead of diameter at breast height. Defaults to \code{diameter} if \code{NULL}.}
+
+\item{bp}{An optional numeric vector of biomass packing values (in m\ifelse{html}{\out{<sup>3</sup>}}{$^3$}). Required
+for a subset of species in \code{\link{eq_biomass_menendez_2022}} (e.g.
+\emph{Pinus halepensis}, \emph{Pinus nigra}, \emph{Quercus suber},
+\emph{Evergreen broadleaves}).}
 
 \item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.}
 }
@@ -38,6 +49,14 @@ dataset \link{biomass_models}. The available models include:
 \itemize{
 \item \strong{\code{\link[=eq_biomass_ruiz_peinado_2011]{eq_biomass_ruiz_peinado_2011()}}}: Developed for softwood species in Spain.
 \item \strong{\code{\link[=eq_biomass_ruiz_peinado_2012]{eq_biomass_ruiz_peinado_2012()}}}: Developed for hardwood species in Spain.
+\item \strong{\code{\link[=eq_biomass_montero_2005]{eq_biomass_montero_2005()}}}: Developed for 35 Spanish species.
+\item \strong{\code{\link[=eq_biomass_dieguez_aranda_2009]{eq_biomass_dieguez_aranda_2009()}}}: Developed for 7 Galician species.
+\item \strong{\code{\link[=eq_biomass_manrique_2017]{eq_biomass_manrique_2017()}}}: Developed for \emph{Quercus petraea} and \emph{Quercus pyrenaica}.
+\item \strong{\code{\link[=eq_biomass_menendez_2022]{eq_biomass_menendez_2022()}}}: Developed for young plantations (< 30 years) of 18
+Spanish species. Uses \code{rcd} (root collar diameter) instead of \code{diameter}; some species
+require \code{bp} (biomass packing) instead of \code{rcd}.
+\item \strong{\code{\link[=eq_biomass_cudjoe_2024]{eq_biomass_cudjoe_2024()}}}: Developed for \emph{Pinus sylvestris} and \emph{Quercus petraea}
+in Castille and León, Spain.
 }
 
 Users can check the list of supported species and their corresponding components


### PR DESCRIPTION
## Summary

Extends `silv_predict_biomass()` to support all 7 allometric biomass models and improves documentation for every `eq_biomass_*()` function. Also adds the poster DOI to `README.md` and resolves the merge conflict in `inst/references.bib`.

### Changes

**`R/predict-biomass.R` — code**
- Add `rcd` (root collar diameter) and `bp` (biomass packing) parameters to `silv_predict_biomass()`. `rcd` defaults to `diameter`; `bp` defaults to `NA`.
- Replace the model-specific dispatch (`if (model@equation %in% c("ruiz-peinado-2011", "ruiz-peinado-2012"))`) with a universal `calc_biomass()` inner function using `eval_env = list(d, h, rcd, bp)` — all 7 models now work.
- Add `return_rmse` / `return_r2` metric handling inside `calc_biomass()`.
- Fix `eq_biomass_cudjoe_2024()` returning `equation = "cudjoe-2017"` instead of `"cudjoe-2024"`.

**`R/predict-biomass.R` — Roxygen2 documentation**
- `silv_predict_biomass()`: add `@param rcd`, `@param bp`; update `@details` listing all 7 models with input requirements.
- `eq_biomass_ruiz_peinado_2011()`: explicit species list (10 softwood) + component hierarchy.
- `eq_biomass_ruiz_peinado_2012()`: explicit species list (13 hardwood) + component hierarchy; fix missing comma in `@seealso`.
- `eq_biomass_dieguez_aranda_2009()`: rewritten `@details`; fix typo "Pinaster radiata" → "Pinus radiata".
- `eq_biomass_montero_2005()`: replace "35 species" with full bulleted list + component hierarchy; fix `@seealso` comma.
- `eq_biomass_manrique_2017()`: structured `@details`; fix "thin branches" → "small branches".
- `eq_biomass_menendez_2022()`: correct species count 15 → 18 + 3 functional groups; document non-standard `rcd`/`bp` requirements.
- `eq_biomass_cudjoe_2024()`: structured `@details`; fix "brances" typo.

**`README.md`**
- Add "Suggested companion reading" section with poster DOI `https://doi.org/10.13140/RG.2.2.28098.75205`.

**`inst/references.bib`**
- Resolve unresolved merge conflict: keep `menendez-2022` and `cudjoe-2024` entries; discard `palahi-2003`.
- Add poster BibTeX entry (`vazquez-veloso_poster_2025`).

---

## Verification

```r
devtools::load_all()

# All 7 models now work with silv_predict_biomass()
silv_predict_biomass(diameter = 20, height = 10,
  model = eq_biomass_ruiz_peinado_2011("Pinus pinaster", "stem"))
# Expected: single numeric biomass value (kg)

silv_predict_biomass(diameter = 20, height = 10,
  model = eq_biomass_ruiz_peinado_2012("Quercus suber", "stem"))
# Expected: single numeric biomass value (kg)

silv_predict_biomass(diameter = 20, height = 10,
  model = eq_biomass_montero_2005("Pinus sylvestris", "AGB"))
# Expected: single numeric biomass value (kg)

silv_predict_biomass(diameter = 20, height = 10,
  model = eq_biomass_dieguez_aranda_2009("Pinus pinaster", "AGB"))
# Expected: single numeric biomass value (kg)

silv_predict_biomass(diameter = 20, height = 10,
  model = eq_biomass_manrique_2017("Quercus petraea", "AGB"))
# Expected: single numeric biomass value (kg)

# menendez-2022: rcd defaults to diameter when not provided
silv_predict_biomass(diameter = 10, height = 4,
  model = eq_biomass_menendez_2022("Fagus sylvatica"))
# Expected: single numeric biomass value (kg) using rcd = 10

# menendez-2022: explicit rcd
silv_predict_biomass(diameter = 10, height = 4, rcd = 8,
  model = eq_biomass_menendez_2022("Pinus sylvestris"))
# Expected: single numeric biomass value (kg) using rcd = 8

silv_predict_biomass(diameter = 20, height = 10,
  model = eq_biomass_cudjoe_2024("Pinus sylvestris", "AGB"))
# Expected: single numeric biomass value (kg)

# Verify cudjoe-2024 equation ID fix
m <- eq_biomass_cudjoe_2024("Pinus sylvestris", "stem")
m@equation  # must print "cudjoe-2024"

# Verify poster DOI in README
any(grepl("10.13140/RG.2.2.28098.75205", readLines("README.md")))
# Expected: TRUE

# Verify bib has no conflict markers
any(grepl("<<<<<<<", readLines("inst/references.bib"), fixed = TRUE))
# Expected: FALSE
```